### PR TITLE
Allow retry of path during hmac validation for a8

### DIFF
--- a/org.gameontext.signed/src/main/java/org/gameontext/signed/SignedRequestHmac.java
+++ b/org.gameontext.signed/src/main/java/org/gameontext/signed/SignedRequestHmac.java
@@ -273,7 +273,7 @@ public class SignedRequestHmac {
                 //is there a prefix?
                 if(baseUri.indexOf('/',1)!=-1){
                     String prefix = baseUri.substring(0,Math.min(baseUri.indexOf('/', 1), baseUri.length()));
-                    Log.log(Level.INFO, this, "HashMismatch, retrying with a8 service prefix {0}",prefix);
+                    //Log.log(Level.INFO, this, "HashMismatch, retrying with a8 service prefix {0}",prefix);
                     stuffToHash = new ArrayList<String>();
                     if ( !oldStyle ) {
                         stuffToHash.add(method);    // (1)


### PR DESCRIPTION
Temporary: A8 places the service name in the path, which leads to the path check failing the hmac because paths are sent to a8 as /map/map/fish but then the call is placed onwards to the service as /map/fish. So the hmac was calculated with /map/map/fish originally by the client, and thus the check fails when the service validates with only /map/fish. This change adds the first path segment back to the path, then revalidates the hmac if it failed initially. 
Once we rewrite the nginx config for a8, this will no longer be required..

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/signed/2)

<!-- Reviewable:end -->
